### PR TITLE
Add support for setting a specific nameserver to resolve the DNS query

### DIFF
--- a/tests/DnsTest.php
+++ b/tests/DnsTest.php
@@ -89,6 +89,18 @@ class DnsTest extends TestCase
         $this->assertEquals('spatie.be', (new Dns('https://SPATIE.be'))->getDomain());
     }
 
+    /** @test */
+    public function it_uses_provided_nameserver_if_set()
+    {
+        $this->assertEquals("ns1.openminds.be", (new Dns("spatie.be", "ns1.openminds.be"))->getNameserver());
+    }
+
+    /** @test */
+    public function it_uses_default_nameserver_if_not_set()
+    {
+        $this->assertEquals(Dns::NAMESERVER_DEFAULT, ($this->dns->getNameserver()));
+    }
+
     protected function assertSeeRecordTypes($records, $type)
     {
         $types = (array) $type;


### PR DESCRIPTION
Sometimes I would like to be able to query specific dns/nameservers to request what their take is on how a domain should be resolved. You can directly query to nameserver to see if a change you made is correct, or you want to check against your ISP dnsserver to see if the change has already propagated downstream.
I extended the class to have support for a custom set nameserver. The old behaviour is still the default behaviour.
There is a little caveat though, as it is hard to parse the answering nameserver from dig, especially without changing the current output format, when no nameserver is predefined and you request the nameserver used it will report back 'default'. This 'default' means the server used by default by dig to resolve the dns queries. If you use a custom dns/nameserver it will report back the explicitly set value for the nameserver.