### PR TITLE
Added ability to get DNS records for subdomains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ $dns->getRecords('A', 'MX'); // returns both A and MX records
 $dns->getRecords(['A', 'MX']); // returns both A and MX records
 ```
 
+To get Subdomains of the domain name use the above Syntax, but first set the sub domain.
+
+``` php
+$dns->setSubDomain("server");
+```
+
+This will change the FQDN (Fully Qualified Domain Name) to "server.spatie.be" which will be tested when using getRecords, so if you need to check the domain again, without the sub domain, you will need to unset the sub domain first.
+
+``` php
+$dns->unsetSubDomain("server");
+```
+
+
 ### Testing
 
 ``` bash

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -34,6 +34,8 @@ class Dns
         $this->nameserver = $nameserver;
 
         $this->domain = $this->sanitizeDomainName($domain);
+
+        $this->fqdn = $this->domain;
     }
 
     public function useNameserver(string $nameserver)
@@ -45,7 +47,23 @@ class Dns
 
     public function getDomain(): string
     {
-        return $this->domain;
+        return $this->fqdn;
+    }
+
+    public function setSubDomain($subDomain): string
+    {
+        $this->subDomain = $subDomain;
+
+        $this->fqdn = $subDomain.".".$this->domain;
+
+        return $this;
+    }
+
+    public function unsetSubDomain()
+    {
+        $this->fqdn = $this->domain;
+
+        return $this->fqdn;
     }
 
     public function getNameserver(): string
@@ -96,7 +114,8 @@ class Dns
     {
         $nameserverPart = $this->getSpecificNameserverPart();
 
-        $command = 'dig +nocmd '.$nameserverPart.' '.escapeshellarg($this->domain)." {$type} +multiline +noall +answer";
+
+        $command = 'dig +nocmd '.$nameserverPart.' '.escapeshellarg($this->fqdn)." {$type} +multiline +noall +answer";
 
         $process = new Process($command);
 

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -54,7 +54,7 @@ class Dns
     {
         $this->subDomain = $subDomain;
 
-        $this->fqdn = $subDomain.".".$this->domain;
+        $this->fqdn = $subDomain.'.'.$this->domain;
 
         return $this;
     }
@@ -113,7 +113,6 @@ class Dns
     protected function getRecordsOfType(string $type): string
     {
         $nameserverPart = $this->getSpecificNameserverPart();
-
 
         $command = 'dig +nocmd '.$nameserverPart.' '.escapeshellarg($this->fqdn)." {$type} +multiline +noall +answer";
 


### PR DESCRIPTION
1) Changed getRecords to test for $this->fqdn (fully qualified domain name) instead of $this->domain
2) Changed constructor, which now also sets $this->fqdn to the value of $this->domain (keeping $this->domain set for later use)
3) added function setSubDomain($subDomain)
    This adds the subdomain to $this->fqdn (subdomain.domain)
4) added function unsetSubDomain()
    This sets $this->fqdn back to the value of $this->domain

