### PR TITLE
Throw a custom exception when dig fails

### DIFF
--- a/src/Dns.php
+++ b/src/Dns.php
@@ -5,6 +5,7 @@ namespace Spatie\Dns;
 use Exception;
 use Symfony\Component\Process\Process;
 use Spatie\Dns\Exceptions\InvalidArgument;
+use Spatie\Dns\Exceptions\CouldNotFetchDns;
 
 class Dns
 {
@@ -103,7 +104,7 @@ class Dns
         $process->run();
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Dns records could not be fetched');
+            throw CouldNotFetchDns::digReturnedWithError(trim($process->getErrorOutput()));
         }
 
         return $process->getOutput();

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Dns;
 
-use Exception;
 use Symfony\Component\Process\Process;
 use Spatie\Dns\Exceptions\InvalidArgument;
 use Spatie\Dns\Exceptions\CouldNotFetchDns;

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -53,6 +53,9 @@ class Dns
         return $this->nameserver;
     }
 
+    /**
+     * @throws CouldNotFetchDns
+     */
     public function getRecords(...$types): string
     {
         $types = $this->determineTypes($types);
@@ -92,6 +95,9 @@ class Dns
         return strtolower($domain);
     }
 
+    /**
+     * @throws CouldNotFetchDns
+     */
     protected function getRecordsOfType(string $type): string
     {
         $nameserverPart = $this->getSpecificNameserverPart();

--- a/src/Exceptions/CouldNotFetchDns.php
+++ b/src/Exceptions/CouldNotFetchDns.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\Dns\Exceptions;
 
-use InvalidArgumentException;
-
-class CouldNotFetchDns extends InvalidArgumentException
+class CouldNotFetchDns extends \Exception
 {
     public static function digReturnedWithError($output)
     {

--- a/src/Exceptions/CouldNotFetchDns.php
+++ b/src/Exceptions/CouldNotFetchDns.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Dns\Exceptions;
+
+use InvalidArgumentException;
+
+class CouldNotFetchDns extends InvalidArgumentException
+{
+    public static function digReturnedWithError($output)
+    {
+        return new static("Dig command failed with message: `{$output}`");
+    }
+}

--- a/tests/DnsTest.php
+++ b/tests/DnsTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Dns\Test;
 use Spatie\Dns\Dns;
 use PHPUnit\Framework\TestCase;
 use Spatie\Dns\Exceptions\InvalidArgument;
+use Spatie\Dns\Exceptions\CouldNotFetchDns;
 
 class DnsTest extends TestCase
 {
@@ -110,8 +111,8 @@ class DnsTest extends TestCase
     /** @test */
     public function it_throws_excpetion_on_failed_to_fetch_dns_record()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Dns records could not be fetched');
+        $this->expectException(CouldNotFetchDns::class);
+        $this->expectExceptionMessage("Dig command failed with message: `dig: couldn't get address for 'dns.spatie.be': not found`");
         (new Dns('https://spatie.be'))->useNameServer('dns.spatie.be')->getRecords('MX');
     }
 


### PR DESCRIPTION
Allows more idiomatic way for users of this library to distinguish between library and application errors.