### PR TITLE
Add support for NAPTR record type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ composer require spatie/dns
 
 ## Usage
 
-The class can get these record types: `A`, `AAAA`, `CNAME`, `NS`, `SOA`, `MX`, `SRV`, `TXT`, `DNSKEY`, `CAA`.
+The class can get these record types: `A`, `AAAA`, `CNAME`, `NS`, `SOA`, `MX`, `SRV`, `TXT`, `DNSKEY`, `CAA`, `NAPTR`.
 
 ``` php
 $dns = new Spatie\Dns\Dns('spatie.be');

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -23,6 +23,7 @@ class Dns
         'TXT',
         'DNSKEY',
         'CAA',
+        'NAPTR',
     ];
 
     public function __construct(string $domain, string $nameserver = '')


### PR DESCRIPTION
Add support for the NAPTR (Naming Authority Pointer) record type.

Defined in [RFC3403](https://tools.ietf.org/html/rfc3403), NAPTR records are commonly used in telephony applications.

Ref: https://en.wikipedia.org/wiki/NAPTR_record

I haven't added any additional tests for this as the spatie.be domain obviously doesn't have any NAPTR records, but it looks like the tests don't cover every single record type at the moment anyway.

P.S. Thank you for the useful and lightweight package!