### PR TITLE
Create Process instance with an array (string deprecated)

### DIFF
--- a/src/Dns.php
+++ b/src/Dns.php
@@ -110,7 +110,7 @@ class Dns
             $type,
             '+multiline',
             '+noall',
-            '+answer'
+            '+answer',
         ]);
 
         $process = new Process($command);

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -102,7 +102,16 @@ class Dns
     {
         $nameserverPart = $this->getSpecificNameserverPart();
 
-        $command = 'dig +nocmd '.$nameserverPart.' '.escapeshellarg($this->domain)." {$type} +multiline +noall +answer";
+        $command = array_filter([
+            'dig',
+            '+nocmd',
+            $nameserverPart,
+            $this->domain,
+            $type,
+            '+multiline',
+            '+noall',
+            '+answer'
+        ]);
 
         $process = new Process($command);
 
@@ -115,12 +124,12 @@ class Dns
         return $process->getOutput();
     }
 
-    protected function getSpecificNameserverPart()
+    protected function getSpecificNameserverPart(): ?string
     {
         if ($this->nameserver === '') {
-            return '';
+            return null;
         }
 
-        return '@'.escapeshellarg($this->nameserver);
+        return '@'.$this->nameserver;
     }
 }


### PR DESCRIPTION
Fixes #29 

As a side note `symfony/process` does the shell argument escaping for you when you pass arguments via the array, so I've taken the calls to `escapeshellarg` out to avoid double escaping.