### PR TITLE
Add .phpunit.result.cache to ignore Git control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache


### PR DESCRIPTION
# Changed log

- This `.phpunit.result.cache` file is generated by `PHPUnit` and it should be ignored on Git version control.