### PR TITLE
Ensure accessed indexes do exist

### DIFF
--- a/src/Records/A.php
+++ b/src/Records/A.php
@@ -9,9 +9,13 @@ class A extends Record
 {
     protected string $ip;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
+
+        if (count($attributes) < 5) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/AAAA.php
+++ b/src/Records/AAAA.php
@@ -9,9 +9,13 @@ class AAAA extends Record
 {
     protected string $ipv6;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
+
+        if (count($attributes) < 5) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/CAA.php
+++ b/src/Records/CAA.php
@@ -13,9 +13,13 @@ class CAA extends Record
     protected string $tag;
     protected string $value;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 7);
+
+        if (count($attributes) < 7) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/CNAME.php
+++ b/src/Records/CNAME.php
@@ -9,9 +9,13 @@ class CNAME extends Record
 {
     protected string $target;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
+
+        if (count($attributes) < 5) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/MX.php
+++ b/src/Records/MX.php
@@ -11,9 +11,13 @@ class MX extends Record
     protected int $pri;
     protected string $target;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 6);
+
+        if (count($attributes) < 6) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/NS.php
+++ b/src/Records/NS.php
@@ -9,9 +9,13 @@ class NS extends Record
 {
     protected string $target;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
+
+        if (count($attributes) < 5) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/Record.php
+++ b/src/Records/Record.php
@@ -54,7 +54,7 @@ abstract class Record implements Stringable
      *
      * @return static
      */
-    abstract public static function parse(string $line): self;
+    abstract public static function parse(string $line): ?self;
 
     abstract public function __toString(): string;
 

--- a/src/Records/SOA.php
+++ b/src/Records/SOA.php
@@ -21,9 +21,13 @@ class SOA extends Record
     protected int $expire;
     protected int $minimum_ttl;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 11);
+
+        if (count($attributes) < 11) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/SRV.php
+++ b/src/Records/SRV.php
@@ -15,9 +15,13 @@ class SRV extends Record
     protected string $target;
     protected int $port;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 8);
+
+        if (count($attributes) < 8) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Records/TXT.php
+++ b/src/Records/TXT.php
@@ -9,9 +9,13 @@ class TXT extends Record
 {
     protected string $txt;
 
-    public static function parse(string $line): self
+    public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
+
+        if (count($attributes) < 5) {
+            return null;
+        }
 
         return static::make([
             'host' => $attributes[0],

--- a/src/Support/Factory.php
+++ b/src/Support/Factory.php
@@ -7,7 +7,7 @@ use Spatie\Dns\Records\Record;
 
 class Factory
 {
-    public function parse(string $type, string $line): Record
+    public function parse(string $type, string $line): ?Record
     {
         return forward_static_call([$this->resolve($type), 'parse'], $line);
     }

--- a/tests/Records/AAAATest.php
+++ b/tests/Records/AAAATest.php
@@ -44,4 +44,12 @@ class AAAATest extends TestCase
 
         $this->assertSame("google.com.\t\t900\tIN\tAAAA\t2a00:1450:400e:800::200e", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = AAAA::parse('google.com.             900     IN      AAAA');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/ATest.php
+++ b/tests/Records/ATest.php
@@ -44,4 +44,12 @@ class ATest extends TestCase
 
         $this->assertSame("spatie.be.\t\t900\tIN\tA\t138.197.187.74", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = A::parse('spatie.be.              900     IN      A');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/CAATest.php
+++ b/tests/Records/CAATest.php
@@ -50,4 +50,12 @@ class CAATest extends TestCase
 
         $this->assertSame("google.com.\t\t86400\tIN\tCAA\t0\tissue\t\"pki.goog\"", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = CAA::parse('google.com.             86400   IN      CAA     0 issue');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/CNAMETest.php
+++ b/tests/Records/CNAMETest.php
@@ -44,4 +44,12 @@ class CNAMETest extends TestCase
 
         $this->assertSame("www.spatie.be.\t\t300\tIN\tCNAME\tspatie.be.", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = CNAME::parse('www.spatie.be.       300     IN      CNAME');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/MXTest.php
+++ b/tests/Records/MXTest.php
@@ -47,4 +47,12 @@ class MXTest extends TestCase
 
         $this->assertSame("spatie.be.\t\t1665\tIN\tMX\t10\taspmx.l.google.com.", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = MX::parse('spatie.be.              1665    IN      MX      10');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/NSTest.php
+++ b/tests/Records/NSTest.php
@@ -44,4 +44,12 @@ class NSTest extends TestCase
 
         $this->assertSame("spatie.be.\t\t82516\tIN\tNS\tns1.openprovider.nl.", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = NS::parse('spatie.be.              82516   IN      NS');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/SOATest.php
+++ b/tests/Records/SOATest.php
@@ -62,4 +62,12 @@ class SOATest extends TestCase
 
         $this->assertSame("spatie.be.\t\t82393\tIN\tSOA\tns1.openprovider.nl.\tdns.openprovider.eu.\t2020100801\t10800\t3600\t604800\t3600", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = SOA::parse('spatie.be.              82393   IN      SOA     ns1.openprovider.nl. dns.openprovider.eu. 2020100801 10800 3600 604800');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/SRVTest.php
+++ b/tests/Records/SRVTest.php
@@ -53,4 +53,12 @@ class SRVTest extends TestCase
 
         $this->assertSame("_http._tcp.mxtoolbox.com.\t\t3600\tIN\tSRV\t10\t100\t80\tmxtoolbox.com.", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = SRV::parse('_http._tcp.mxtoolbox.com. 3600  IN      SRV     10 100 80');
+
+        $this->assertNull($record);
+    }
 }

--- a/tests/Records/TXTTest.php
+++ b/tests/Records/TXTTest.php
@@ -44,4 +44,12 @@ class TXTTest extends TestCase
 
         $this->assertSame("spatie.be.\t\t594\tIN\tTXT\t\"v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all\"", strval($record));
     }
+
+    /** @test */
+    public function it_return_null_for_to_few_attributs()
+    {
+        $record = TXT::parse('spatie.be.              594     IN      TXT');
+
+        $this->assertNull($record);
+    }
 }


### PR DESCRIPTION
Hi,

Another "problem" I noticed, is that the parts from a dig command output are accessed directly. Even if the count of attributes does not match the expected ones.

This PR fixes this, by checking the count of attributes before accessing them.

Hope this helps