### PR TITLE
Handle missing attributes by allowing them to be empty/null or 0

### DIFF
--- a/src/Records/A.php
+++ b/src/Records/A.php
@@ -7,18 +7,18 @@ namespace Spatie\Dns\Records;
  */
 class A extends Record
 {
-    protected string $ip;
+    protected ?string $ip;
 
     public static function parse(string $line): self
     {
         $attributes = static::lineToArray($line, 5);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'ip' => $attributes[4],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'ip' => $attributes[4] ?? null,
         ]);
     }
 

--- a/src/Records/AAAA.php
+++ b/src/Records/AAAA.php
@@ -7,18 +7,18 @@ namespace Spatie\Dns\Records;
  */
 class AAAA extends Record
 {
-    protected string $ipv6;
+    protected ?string $ipv6;
 
     public static function parse(string $line): self
     {
         $attributes = static::lineToArray($line, 5);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'ipv6' => $attributes[4],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'ipv6' => $attributes[4] ?? null,
         ]);
     }
 

--- a/src/Records/CAA.php
+++ b/src/Records/CAA.php
@@ -18,13 +18,13 @@ class CAA extends Record
         $attributes = static::lineToArray($line, 7);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'flags' => $attributes[4],
-            'tag' => $attributes[5],
-            'value' => $attributes[6],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'flags' => $attributes[4] ?? null,
+            'tag' => $attributes[5] ?? null,
+            'value' => $attributes[6] ?? null,
         ]);
     }
 
@@ -33,12 +33,12 @@ class CAA extends Record
         return "{$this->host}.\t\t{$this->ttl}\t{$this->class}\t{$this->type}\t{$this->flags}\t{$this->tag}\t\"{$this->value}\"";
     }
 
-    protected function castFlags(string $value): int
+    protected function castFlags(?string $value): int
     {
         return $this->prepareInt($value);
     }
 
-    protected function castValue(string $value): string
+    protected function castValue(?string $value): string
     {
         return $this->prepareText($value);
     }

--- a/src/Records/CNAME.php
+++ b/src/Records/CNAME.php
@@ -14,11 +14,11 @@ class CNAME extends Record
         $attributes = static::lineToArray($line, 5);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'target' => $attributes[4],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'target' => $attributes[4] ?? null,
         ]);
     }
 
@@ -27,7 +27,7 @@ class CNAME extends Record
         return "{$this->host}.\t\t{$this->ttl}\t{$this->class}\t{$this->type}\t{$this->target}.";
     }
 
-    protected function castTarget(string $value): string
+    protected function castTarget(?string $value): string
     {
         return $this->prepareDomain($value);
     }

--- a/src/Records/MX.php
+++ b/src/Records/MX.php
@@ -16,12 +16,12 @@ class MX extends Record
         $attributes = static::lineToArray($line, 6);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'pri' => $attributes[4],
-            'target' => $attributes[5],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'pri' => $attributes[4] ?? null,
+            'target' => $attributes[5] ?? null,
         ]);
     }
 
@@ -35,7 +35,7 @@ class MX extends Record
         return $this->prepareInt($value);
     }
 
-    protected function castTarget(string $value): string
+    protected function castTarget(?string $value): string
     {
         return $this->prepareDomain($value);
     }

--- a/src/Records/NS.php
+++ b/src/Records/NS.php
@@ -14,11 +14,11 @@ class NS extends Record
         $attributes = static::lineToArray($line, 5);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'target' => $attributes[4],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'target' => $attributes[4] ?? null,
         ]);
     }
 
@@ -27,7 +27,7 @@ class NS extends Record
         return "{$this->host}.\t\t{$this->ttl}\t{$this->class}\t{$this->type}\t{$this->target}.";
     }
 
-    protected function castTarget(string $value): string
+    protected function castTarget(?string $value): string
     {
         return $this->prepareDomain($value);
     }

--- a/src/Records/Record.php
+++ b/src/Records/Record.php
@@ -92,8 +92,12 @@ abstract class Record implements Stringable
         return $value;
     }
 
-    protected function prepareDomain(string $value): string
+    protected function prepareDomain(?string $value): string
     {
+        if (is_null($value)) {
+            return '';
+        }
+
         return strval(new Domain(trim($value, '.')));
     }
 
@@ -102,12 +106,12 @@ abstract class Record implements Stringable
         return intval($value);
     }
 
-    protected function prepareText(string $value): string
+    protected function prepareText(?string $value): string
     {
         return trim($value, '"');
     }
 
-    protected function castHost(string $value): string
+    protected function castHost(?string $value): string
     {
         return $this->prepareDomain($value);
     }
@@ -117,12 +121,12 @@ abstract class Record implements Stringable
         return $this->prepareInt($value);
     }
 
-    protected function castClass(string $value): string
+    protected function castClass(?string $value): string
     {
         return mb_strtoupper($value);
     }
 
-    protected function castType(string $value): string
+    protected function castType(?string $value): string
     {
         return mb_strtoupper($value);
     }

--- a/src/Records/SOA.php
+++ b/src/Records/SOA.php
@@ -26,17 +26,17 @@ class SOA extends Record
         $attributes = static::lineToArray($line, 11);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'mname' => $attributes[4],
-            'rname' => $attributes[5],
-            'serial' => $attributes[6],
-            'refresh' => $attributes[7],
-            'retry' => $attributes[8],
-            'expire' => $attributes[9],
-            'minimum-ttl' => $attributes[10],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'mname' => $attributes[4] ?? null,
+            'rname' => $attributes[5] ?? null,
+            'serial' => $attributes[6] ?? null,
+            'refresh' => $attributes[7] ?? null,
+            'retry' => $attributes[8] ?? null,
+            'expire' => $attributes[9] ?? null,
+            'minimum-ttl' => $attributes[10] ?? null,
         ]);
     }
 
@@ -45,12 +45,12 @@ class SOA extends Record
         return "{$this->host}.\t\t{$this->ttl}\t{$this->class}\t{$this->type}\t{$this->mname}.\t{$this->rname}.\t{$this->serial}\t{$this->refresh}\t{$this->retry}\t{$this->expire}\t{$this->minimum_ttl}";
     }
 
-    protected function castMname(string $value): string
+    protected function castMname(?string $value): string
     {
         return $this->prepareDomain($value);
     }
 
-    protected function castRname(string $value): string
+    protected function castRname(?string $value): string
     {
         return $this->prepareDomain($value);
     }

--- a/src/Records/SRV.php
+++ b/src/Records/SRV.php
@@ -20,14 +20,14 @@ class SRV extends Record
         $attributes = static::lineToArray($line, 8);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'pri' => $attributes[4],
-            'weight' => $attributes[5],
-            'port' => $attributes[6],
-            'target' => $attributes[7],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'pri' => $attributes[4] ?? null,
+            'weight' => $attributes[5] ?? null,
+            'port' => $attributes[6] ?? null,
+            'target' => $attributes[7] ?? null,
         ]);
     }
 
@@ -51,7 +51,7 @@ class SRV extends Record
         return $this->prepareInt($value);
     }
 
-    protected function castTarget(string $value): string
+    protected function castTarget(?string $value): string
     {
         return $this->prepareDomain($value);
     }

--- a/src/Records/TXT.php
+++ b/src/Records/TXT.php
@@ -14,11 +14,11 @@ class TXT extends Record
         $attributes = static::lineToArray($line, 5);
 
         return static::make([
-            'host' => $attributes[0],
-            'ttl' => $attributes[1],
-            'class' => $attributes[2],
-            'type' => $attributes[3],
-            'txt' => $attributes[4],
+            'host' => $attributes[0] ?? null,
+            'ttl' => $attributes[1] ?? null,
+            'class' => $attributes[2] ?? null,
+            'type' => $attributes[3] ?? null,
+            'txt' => $attributes[4] ?? null,
         ]);
     }
 
@@ -27,7 +27,7 @@ class TXT extends Record
         return "{$this->host}.\t\t{$this->ttl}\t{$this->class}\t{$this->type}\t\"{$this->txt}\"";
     }
 
-    protected function castTxt(string $value): string
+    protected function castTxt(?string $value): string
     {
         return $this->prepareText($value);
     }

--- a/tests/Records/AAAATest.php
+++ b/tests/Records/AAAATest.php
@@ -63,4 +63,12 @@ class AAAATest extends TestCase
         $this->assertSame('AAAA', $data['type']);
         $this->assertSame('2a00:1450:400e:800::200e', $data['ipv6']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = AAAA::parse('google.com.             900     IN      AAAA');
+
+        $this->assertSame(null, $record->ipv6());
+    }
 }

--- a/tests/Records/ATest.php
+++ b/tests/Records/ATest.php
@@ -63,4 +63,12 @@ class ATest extends TestCase
         $this->assertSame('A', $data['type']);
         $this->assertSame('138.197.187.74', $data['ip']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = A::parse('spatie.be.              900     IN      A');
+
+        $this->assertSame(null, $record->ip());
+    }
 }

--- a/tests/Records/CAATest.php
+++ b/tests/Records/CAATest.php
@@ -73,4 +73,12 @@ class CAATest extends TestCase
         $this->assertSame('issue', $data['tag']);
         $this->assertSame('pki.goog', $data['value']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = CAA::parse('google.com.             86400   IN      CAA     0 issue');
+
+        $this->assertSame('', $record->value());
+    }
 }

--- a/tests/Records/CNAMETest.php
+++ b/tests/Records/CNAMETest.php
@@ -63,4 +63,12 @@ class CNAMETest extends TestCase
         $this->assertSame('CNAME', $data['type']);
         $this->assertSame('spatie.be', $data['target']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = CNAME::parse('www.spatie.be.       300     IN      CNAME');
+
+        $this->assertSame('', $record->target());
+    }
 }

--- a/tests/Records/MXTest.php
+++ b/tests/Records/MXTest.php
@@ -68,4 +68,12 @@ class MXTest extends TestCase
         $this->assertSame(10, $data['pri']);
         $this->assertSame('aspmx.l.google.com', $data['target']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = MX::parse('spatie.be.              1665    IN      MX      10');
+
+        $this->assertSame('', $record->target());
+    }
 }

--- a/tests/Records/NSTest.php
+++ b/tests/Records/NSTest.php
@@ -63,4 +63,12 @@ class NSTest extends TestCase
         $this->assertSame('NS', $data['type']);
         $this->assertSame('ns1.openprovider.nl', $data['target']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = NS::parse('spatie.be.              82516   IN      NS');
+
+        $this->assertSame('', $record->target());
+    }
 }

--- a/tests/Records/SOATest.php
+++ b/tests/Records/SOATest.php
@@ -93,4 +93,12 @@ class SOATest extends TestCase
         $this->assertSame(604800, $data['expire']);
         $this->assertSame(3600, $data['minimum_ttl']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = SOA::parse('spatie.be.              82393   IN      SOA     ns1.openprovider.nl. dns.openprovider.eu. 2020100801 10800 3600 604800');
+
+        $this->assertSame(0, $record->minimum_ttl());
+    }
 }

--- a/tests/Records/SRVTest.php
+++ b/tests/Records/SRVTest.php
@@ -78,4 +78,12 @@ class SRVTest extends TestCase
         $this->assertSame(80, $data['port']);
         $this->assertSame('mxtoolbox.com', $data['target']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = SRV::parse('_http._tcp.mxtoolbox.com. 3600  IN      SRV     10 100 80');
+
+        $this->assertSame('', $record->target());
+    }
 }

--- a/tests/Records/TXTTest.php
+++ b/tests/Records/TXTTest.php
@@ -63,4 +63,12 @@ class TXTTest extends TestCase
         $this->assertSame('TXT', $data['type']);
         $this->assertSame('v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all', $data['txt']);
     }
+
+    /** @test */
+    public function it_does_not_throw_a_warning_for_insufficient_attributes()
+    {
+        $record = TXT::parse('spatie.be.              594     IN      TXT');
+
+        $this->assertSame('', $record->txt());
+    }
 }


### PR DESCRIPTION
This PR adds a more loose way to handle invalid lines parsed by the certain record type classes.

Follow our discussion for more details: https://github.com/spatie/dns/pull/68