### PR TITLE
Update change about php breaking compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to `dns` will be documented in this file
 - near-total rewrite
 - added methods on record types 
 - added support for multiple handlers
+- drop support for any PHP 7.x (require >= 8.0)
 
 ## 1.6.0 - 2020-12-02
 


### PR DESCRIPTION
Since 2.x, php 8.0 is required