### PR TITLE
Added support for long TXT records (see rfc4408, section 3.1.3)

### DIFF
--- a/src/Records/Record.php
+++ b/src/Records/Record.php
@@ -108,7 +108,7 @@ abstract class Record implements Stringable
 
     protected function prepareText(string $value): string
     {
-        return trim($value, '"');
+        return str_replace('" "', '', trim($value, '"'));
     }
 
     protected function castHost(string $value): string

--- a/tests/Records/TXTTest.php
+++ b/tests/Records/TXTTest.php
@@ -20,6 +20,14 @@ class TXTTest extends TestCase
     }
 
     /** @test */
+    public function it_can_parse_long_txt_string()
+    {
+        $record = TXT::parse('spatie.be.              594     IN      TXT     "v=spf1 a mx ip4:100.101.102.103 ip4:104.105.106.107 ip4:108.109.110.111 ip6:1a1a:1a1a:1a1a:1a1a:1a1a:1a1a:1a1a:1a1a include:_spf.google.com include:_spf.c" "reatesend.com ~all"');
+
+        $this->assertSame('v=spf1 a mx ip4:100.101.102.103 ip4:104.105.106.107 ip4:108.109.110.111 ip6:1a1a:1a1a:1a1a:1a1a:1a1a:1a1a:1a1a:1a1a include:_spf.google.com include:_spf.createsend.com ~all', $record->txt());
+    }
+
+    /** @test */
     public function it_can_make_from_array()
     {
         $record = TXT::make([


### PR DESCRIPTION
According to [rfc4408 section 3.1.3](https://datatracker.ietf.org/doc/html/rfc4408#section-3.1.3), a TXT record can contain multiple strings.

This PR adds support for parsing those.

The test added shows that when a TXT record exists out of `include:_spf.c" "reatesend.com`, that it can be parsed as `include:_spf.createsend.com`.
The SPF record in the test is a real one that exists in the wild, but I've replace the ip4 and ip6 entries with some dummy ones.