### PR TITLE
Improved handling of errors when dns_get_record function fails.

### DIFF
--- a/src/Exceptions/CouldNotFetchDns.php
+++ b/src/Exceptions/CouldNotFetchDns.php
@@ -18,4 +18,13 @@ class CouldNotFetchDns extends RuntimeException
 
         return new static("Dig command failed with message: `{$output}`");
     }
+
+    public static function dnsGetRecordReturnedWithError(string $error): self
+    {
+        if ($error === '') {
+            $error = 'dns_get_record function failed';
+        }
+
+        return new static($error);
+    }
 }

--- a/src/Handlers/DnsGetRecord.php
+++ b/src/Handlers/DnsGetRecord.php
@@ -2,11 +2,24 @@
 
 namespace Spatie\Dns\Handlers;
 
+use Spatie\Dns\Exceptions\CouldNotFetchDns;
+
 class DnsGetRecord extends Handler
 {
     public function __invoke(string $domain, int $flag, string $type): array
     {
-        $records = dns_get_record($domain, $flag);
+        $records = false;
+        $error = '';
+
+        try {
+            $records = dns_get_record($domain, $flag);
+        } catch (\Throwable $ex) {
+            $error = $ex->getMessage();
+        }
+
+        if ($records === false) {
+            throw CouldNotFetchDns::dnsGetRecordReturnedWithError($error);
+        }
 
         return $this->transform($type, $records);
     }

--- a/tests/DnsTest.php
+++ b/tests/DnsTest.php
@@ -7,12 +7,14 @@ use ReflectionClass;
 use Spatie\Dns\Dns;
 use Spatie\Dns\Exceptions\CouldNotFetchDns;
 use Spatie\Dns\Exceptions\InvalidArgument;
+use Spatie\Dns\Handlers\DnsGetRecord;
 use Spatie\Dns\Records\A;
 use Spatie\Dns\Records\MX;
 use Spatie\Dns\Records\NS;
 use Spatie\Dns\Records\Record;
 use Spatie\Dns\Records\SOA;
 use Spatie\Dns\Support\Collection;
+use Spatie\Dns\Support\Factory;
 use Spatie\Dns\Test\TestClasses\CustomHandler;
 
 class DnsTest extends TestCase
@@ -148,6 +150,18 @@ class DnsTest extends TestCase
         $this->dns
             ->useNameserver('dns.spatie.be')
             ->getRecords('spatie.be', DNS_A);
+    }
+
+    /** @test */
+    public function it_throws_exception_on_failed_to_fetch_dns_record_with_dns_get_record_function()
+    {
+        $this->expectException(CouldNotFetchDns::class);
+        $this->expectExceptionMessage('dns_get_record(): A temporary server error occurred.');
+
+        $this->dns
+            ->useHandlers([new DnsGetRecord(new Factory())])
+            ->useNameserver('dns.spatie.be')
+            ->getRecords('non-existing-domain.whatever', DNS_NS);
     }
 
     /** @test */


### PR DESCRIPTION
This was discovered on a server where `dig` was not available which means the `DnsGetRecord` handler is getting used.

When trying to fetch the `NS` records using `dns_get_record` with a specific domain name this failed with an error:
```
Spatie\Dns\Handlers\Handler::transform(): Argument #2 ($records) must be of type array, bool given, called in vendor/spatie/dns/src/Handlers/DnsGetRecord.php on line 11
```

According to [the documentation](https://www.php.net/manual/en/function.dns-get-record.php#refsect1-function.dns-get-record-returnvalues), `dns_get_record` can return `false` on failure and this wasn't handled in this library yet.

----

For some reason, on my local system, there is a 1 minute delay when calling `dns_get_record` in such a specific case that gives an error, which means that the unit tests seems to hang for a bit, but eventually it finishes.
On a server where we run the same code, this 1 minute delay for some reason doesn't occur, so not exactly sure what triggers this.