### PR TITLE
Add PTR ipv6 tests.

### DIFF
--- a/tests/Records/PTRTest.php
+++ b/tests/Records/PTRTest.php
@@ -7,49 +7,57 @@ use Spatie\Dns\Records\PTR;
 
 class PTRTest extends TestCase
 {
-    /** @test */
-    public function it_can_parse_string()
+    public function rDnsProvider()
     {
-        $record = PTR::parse('1.73.1.5.in-addr.arpa.              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
+        return [
+            ['1.73.1.5.in-addr.arpa.', '1.73.1.5.in-addr.arpa'],
+            ['1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.c.f.6.7.0.a.2.ip6.arpa.', '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.c.f.6.7.0.a.2.ip6.arpa'],
+        ];
+    }
 
-        $this->assertSame('1.73.1.5.in-addr.arpa', $record->reversDnsName());
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_parse_string($rDNS, $trimmedRDNS)
+    {
+        $record = PTR::parse($rDNS . '              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
+
+        $this->assertSame($trimmedRDNS, $record->reversDnsName());
         $this->assertSame(3600, $record->ttl());
         $this->assertSame('IN', $record->class());
         $this->assertSame('PTR', $record->type());
         $this->assertSame('ae0.452.fra.as205948.creoline.net.', $record->name());
     }
 
-    /** @test */
-    public function it_can_make_from_array()
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_make_from_array($rDNS, $trimmedRDNS)
     {
         $record = PTR::make([
-            'reversDnsName' => '1.73.1.5.in-addr.arpa.',
+            'reversDnsName' => $rDNS,
             'class' => 'IN',
             'ttl' => 3600,
             'type' => 'PTR',
             'name' => 'ae0.452.fra.as205948.creoline.net.',
         ]);
 
-        $this->assertSame('1.73.1.5.in-addr.arpa', $record->reversDnsName());
+        $this->assertSame($trimmedRDNS, $record->reversDnsName());
         $this->assertSame(3600, $record->ttl());
         $this->assertSame('IN', $record->class());
         $this->assertSame('PTR', $record->type());
         $this->assertSame('ae0.452.fra.as205948.creoline.net.', $record->name());
     }
 
-    /** @test */
-    public function it_can_transform_to_string()
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_transform_to_string($rDNS)
     {
-        $record = PTR::parse('1.73.1.5.in-addr.arpa.              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
+        $record = PTR::parse($rDNS. '              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
 
-        $this->assertSame("1.73.1.5.in-addr.arpa.\t\t3600\tIN\tPTR\tae0.452.fra.as205948.creoline.net.", strval($record));
+        $this->assertSame($rDNS . "\t\t3600\tIN\tPTR\tae0.452.fra.as205948.creoline.net.", strval($record));
     }
 
-    /** @test */
-    public function it_can_be_converted_to_an_array()
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_be_converted_to_an_array($rDNS, $trimmedRDNS)
     {
         $record = PTR::make([
-            'reversDnsName' => '1.73.1.5.in-addr.arpa.',
+            'reversDnsName' => $rDNS,
             'class' => 'IN',
             'ttl' => 3600,
             'type' => 'PTR',
@@ -57,17 +65,17 @@ class PTRTest extends TestCase
         ]);
 
         $data = $record->toArray();
-        $this->assertSame('1.73.1.5.in-addr.arpa', $data['reversDnsName']);
+        $this->assertSame($trimmedRDNS, $data['reversDnsName']);
         $this->assertSame(3600, $data['ttl']);
         $this->assertSame('IN', $data['class']);
         $this->assertSame('PTR', $data['type']);
         $this->assertSame('ae0.452.fra.as205948.creoline.net.', $data['name']);
     }
 
-    /** @test */
-    public function it_return_null_for_to_few_attributes()
+    /** @test @dataProvider rDnsProvider */
+    public function it_return_null_for_to_few_attributes($rDNS)
     {
-        $record = PTR::parse('1.73.1.5.in-addr.arpa.              3600     IN      PTR');
+        $record = PTR::parse($rDNS . '              3600     IN      PTR');
 
         $this->assertNull($record);
     }

--- a/tests/Support/FactoryTest.php
+++ b/tests/Support/FactoryTest.php
@@ -44,6 +44,7 @@ class FactoryTest extends TestCase
             [MX::class, 'spatie.be.              1665    IN      MX      10 ASPMX.L.GOOGLE.COM.'],
             [NS::class, 'spatie.be.              82516   IN      NS      ns1.openprovider.nl.'],
             [PTR::class, '1.73.1.5.in-addr.arpa.              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.'],
+            [PTR::class, '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.c.f.6.7.0.a.2.ip6.arpa              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.'],
             [SOA::class, 'spatie.be.              82393   IN      SOA     ns1.openprovider.nl. dns.openprovider.eu. 2020100801 10800 3600 604800 3600'],
             [SRV::class, '_http._tcp.mxtoolbox.com. 3600  IN      SRV     10 100 80 mxtoolbox.com.'],
             [TXT::class, 'spatie.be.              594     IN      TXT     "v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all"'],


### PR DESCRIPTION
To clarify support for ipv6, I have added tests for ipv6 revers DNS names to the PTRTest class.