### PR TITLE
Fix PTR property naming.

### DIFF
--- a/src/Records/PTR.php
+++ b/src/Records/PTR.php
@@ -3,12 +3,11 @@
 namespace Spatie\Dns\Records;
 
 /**
- * @method string reversDnsName()
+ * @method string target()
  */
 class PTR extends Record
 {
-    protected string $reversDnsName;
-    protected string $name;
+    protected string $target;
 
     public static function parse(string $line): ?self
     {
@@ -19,32 +18,27 @@ class PTR extends Record
         }
 
         return static::make([
-            'reversDnsName' => $attributes[0],
+            'host' => $attributes[0],
             'ttl' => $attributes[1],
             'class' => $attributes[2],
             'type' => $attributes[3],
-            'name' => $attributes[4],
+            'target' => $attributes[4],
         ]);
     }
 
     public function __toString(): string
     {
-        return "{$this->reversDnsName}.\t\t{$this->ttl}\t{$this->class}\t{$this->type}\t{$this->name}";
+        return "{$this->host}.\t\t{$this->ttl}\t{$this->class}\t{$this->type}\t{$this->target}";
     }
 
     public function toArray()
     {
         return [
-            'reversDnsName' => $this->reversDnsName,
+            'host' => $this->host,
             'ttl' => $this->ttl,
             'class' => $this->class,
             'type' => $this->type,
-            'name' => $this->name,
+            'target' => $this->target,
         ];
-    }
-
-    protected function castReversDnsName(string $value): string
-    {
-        return $this->prepareDomain($value);
     }
 }

--- a/tests/DnsTest.php
+++ b/tests/DnsTest.php
@@ -10,6 +10,7 @@ use Spatie\Dns\Exceptions\InvalidArgument;
 use Spatie\Dns\Records\A;
 use Spatie\Dns\Records\MX;
 use Spatie\Dns\Records\NS;
+use Spatie\Dns\Records\PTR;
 use Spatie\Dns\Records\Record;
 use Spatie\Dns\Records\SOA;
 use Spatie\Dns\Support\Collection;
@@ -115,6 +116,26 @@ class DnsTest extends TestCase
         $records = $this->dns->getRecords('www.opendor.me', DNS_A);
 
         $this->assertOnlySeeRecordTypes($records, [A::class]);
+    }
+
+    /** @test */
+    public function it_can_fetch_ptr_record()
+    {
+        $records = $this->dns->getRecords('1.73.1.5.in-addr.arpa', DNS_PTR);
+        $record = array_pop($records);
+
+        $ptrRecord = PTR::make([
+            'host' => '1.73.1.5.in-addr.arpa.',
+            'class' => 'IN',
+            'ttl' => 3600,
+            'type' => 'PTR',
+            'target' => 'ae0.452.fra.as205948.creoline.net.',
+        ]);
+
+        $this->assertSame(
+            [$record->host(), $record->class(), $record->type(), $record->target()],
+            [$ptrRecord->host(), $ptrRecord->class(), $ptrRecord->type(), $ptrRecord->target()]
+        );
     }
 
     /** @test */

--- a/tests/Records/PTRTest.php
+++ b/tests/Records/PTRTest.php
@@ -7,67 +7,75 @@ use Spatie\Dns\Records\PTR;
 
 class PTRTest extends TestCase
 {
-    /** @test */
-    public function it_can_parse_string()
+    public function rDnsProvider()
     {
-        $record = PTR::parse('1.73.1.5.in-addr.arpa.              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
+        return [
+            ['1.73.1.5.in-addr.arpa.', '1.73.1.5.in-addr.arpa'],
+            ['1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.c.f.6.7.0.a.2.ip6.arpa.', '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.c.f.6.7.0.a.2.ip6.arpa'],
+        ];
+    }
 
-        $this->assertSame('1.73.1.5.in-addr.arpa', $record->reversDnsName());
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_parse_string($rDNS, $trimmedRDNS)
+    {
+        $record = PTR::parse($rDNS . '              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
+
+        $this->assertSame($trimmedRDNS, $record->host());
         $this->assertSame(3600, $record->ttl());
         $this->assertSame('IN', $record->class());
         $this->assertSame('PTR', $record->type());
-        $this->assertSame('ae0.452.fra.as205948.creoline.net.', $record->name());
+        $this->assertSame('ae0.452.fra.as205948.creoline.net.', $record->target());
     }
 
-    /** @test */
-    public function it_can_make_from_array()
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_make_from_array($rDNS, $trimmedRDNS)
     {
         $record = PTR::make([
-            'reversDnsName' => '1.73.1.5.in-addr.arpa.',
+            'host' => $rDNS,
             'class' => 'IN',
             'ttl' => 3600,
             'type' => 'PTR',
-            'name' => 'ae0.452.fra.as205948.creoline.net.',
+            'target' => 'ae0.452.fra.as205948.creoline.net.',
         ]);
 
-        $this->assertSame('1.73.1.5.in-addr.arpa', $record->reversDnsName());
+        $this->assertSame($trimmedRDNS, $record->host());
         $this->assertSame(3600, $record->ttl());
         $this->assertSame('IN', $record->class());
         $this->assertSame('PTR', $record->type());
-        $this->assertSame('ae0.452.fra.as205948.creoline.net.', $record->name());
+        $this->assertSame('ae0.452.fra.as205948.creoline.net.', $record->target());
     }
 
-    /** @test */
-    public function it_can_transform_to_string()
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_transform_to_string($rDNS)
     {
-        $record = PTR::parse('1.73.1.5.in-addr.arpa.              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
+        $record = PTR::parse($rDNS. '              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
 
-        $this->assertSame("1.73.1.5.in-addr.arpa.\t\t3600\tIN\tPTR\tae0.452.fra.as205948.creoline.net.", strval($record));
+        $this->assertSame($rDNS . "\t\t3600\tIN\tPTR\tae0.452.fra.as205948.creoline.net.", strval($record));
     }
 
-    /** @test */
-    public function it_can_be_converted_to_an_array()
+    /** @test @dataProvider rDnsProvider */
+    public function it_can_be_converted_to_an_array($rDNS, $trimmedRDNS)
     {
         $record = PTR::make([
-            'reversDnsName' => '1.73.1.5.in-addr.arpa.',
+            'host' => $rDNS,
             'class' => 'IN',
             'ttl' => 3600,
             'type' => 'PTR',
-            'name' => 'ae0.452.fra.as205948.creoline.net.',
+            'target' => 'ae0.452.fra.as205948.creoline.net.',
         ]);
 
         $data = $record->toArray();
-        $this->assertSame('1.73.1.5.in-addr.arpa', $data['reversDnsName']);
+        $this->assertSame($trimmedRDNS, $data['host']);
         $this->assertSame(3600, $data['ttl']);
         $this->assertSame('IN', $data['class']);
         $this->assertSame('PTR', $data['type']);
-        $this->assertSame('ae0.452.fra.as205948.creoline.net.', $data['name']);
+        $this->assertSame('ae0.452.fra.as205948.creoline.net.', $data['target']);
     }
 
-    /** @test */
-    public function it_return_null_for_to_few_attributes()
+    /** @test @dataProvider rDnsProvider */
+    public function it_return_null_for_to_few_attributes($rDNS)
     {
-        $record = PTR::parse('1.73.1.5.in-addr.arpa.              3600     IN      PTR');
+        $record = PTR::parse($rDNS . '              3600     IN      PTR');
 
         $this->assertNull($record);
     }

--- a/tests/Support/FactoryTest.php
+++ b/tests/Support/FactoryTest.php
@@ -44,6 +44,7 @@ class FactoryTest extends TestCase
             [MX::class, 'spatie.be.              1665    IN      MX      10 ASPMX.L.GOOGLE.COM.'],
             [NS::class, 'spatie.be.              82516   IN      NS      ns1.openprovider.nl.'],
             [PTR::class, '1.73.1.5.in-addr.arpa.              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.'],
+            [PTR::class, '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.c.f.6.7.0.a.2.ip6.arpa              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.'],
             [SOA::class, 'spatie.be.              82393   IN      SOA     ns1.openprovider.nl. dns.openprovider.eu. 2020100801 10800 3600 604800 3600'],
             [SRV::class, '_http._tcp.mxtoolbox.com. 3600  IN      SRV     10 100 80 mxtoolbox.com.'],
             [TXT::class, 'spatie.be.              594     IN      TXT     "v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all"'],


### PR DESCRIPTION
Changed property names in the PTR class.
Bug description: Calls to dns_get_record($foo, DNS_PTR) failed to match 'target' to 'name' and  'host' to 'reversDnsName' [sic!].
Changed property names from
'reversDnsName' [sic!] to 'host'
and
'name' to 'target'.

Added a test to DnsTest for fetching a PTR record.
Also added tests for ipv6 revers DNS names to the PTRTest class, to clarify support for ipv6.