### PR TITLE
allow to query NS on root or tld nameservers

### DIFF
--- a/src/Handlers/Dig.php
+++ b/src/Handlers/Dig.php
@@ -52,6 +52,8 @@ class Dig extends Handler
             'dig',
             '+nocmd',
             '+noall',
+            '+authority',
+            '+answer',
             '+nomultiline',
             '+answer',
             '+tries=2',


### PR DESCRIPTION
My current usecase is to fetch the authoritative nameservers for a given domain starting from the root nameservers. Thus i query a root nameserver for the tld (e.g. `.ch`) with type `NS`. With the `DnsGetRecord` Handler that worked well (I guess partly because dns_get_records does not support to use a specific nameserver). After switching to `Dig` Handler my code was broken because of the `+noall` cli argument for dig. With this PR I added `+authority` (and `+answer` which is not necessary but declarative this way) to the cli arguments which then show the nameservers under the `AUTHORITY` section.