### PR TITLE
Make dig also work on Linux/MacOS

### DIFF
--- a/src/Handlers/Dig.php
+++ b/src/Handlers/Dig.php
@@ -32,7 +32,7 @@ class Dig extends Handler
 
     public function canHandle(): bool
     {
-        if (! $digPath = (new ExecutableFinder())->find('dig')) {
+        if (! $digPath = (new ExecutableFinder())->find('dig', null, ['/usr/bin'])) {
             return false;
         }
 


### PR DESCRIPTION
Add extra dir `/usr/bin` to Dig::canHandle ExecutableFinder to make dig work on Linux/MacOS