### PR TITLE
fix(dig): tell dig to not convert idn to locale string

### DIFF
--- a/src/Handlers/Dig.php
+++ b/src/Handlers/Dig.php
@@ -52,6 +52,7 @@ class Dig extends Handler
             'dig',
             '+nocmd',
             '+noall',
+            '+noidnout',
             '+authority',
             '+answer',
             '+nomultiline',


### PR DESCRIPTION
When fetching a dns with special utf8 characters (xn--) dig will try by default to convert it, however it require some locales and since there are no env variable in the process defining it (LANG env var) it currently fails. This change make dig to no try to convert this domain in this case (which works for mostly all dns providers)