### PR TITLE
Fix: TXT parsing

### DIFF
--- a/tests/DnsTest.php
+++ b/tests/DnsTest.php
@@ -129,7 +129,7 @@ class DnsTest extends TestCase
             'class' => 'IN',
             'ttl' => 3600,
             'type' => 'PTR',
-            'target' => 'ae0.452.fra.as205948.creoline.net.',
+            'target' => 'ae0.452.fra1.de.creoline.net.',
         ]);
 
         $this->assertSame(

--- a/tests/Records/TXTTest.php
+++ b/tests/Records/TXTTest.php
@@ -79,4 +79,26 @@ class TXTTest extends TestCase
 
         $this->assertNull($record);
     }
+    /** @test */
+    public function it_can_parse_a_string_with_double_space()
+    {
+        $record = TXT::parse('spatie.be.              594     IN      TXT     "test 2  7"');
+
+        $this->assertSame('spatie.be', $record->host());
+        $this->assertSame(594, $record->ttl());
+        $this->assertSame('IN', $record->class());
+        $this->assertSame('TXT', $record->type());
+        $this->assertSame('test 2  7', $record->txt());
+    }
+    /** @test */
+    public function it_can_parse_a_string_with_a_double_quote()
+    {
+        $record = TXT::parse('spatie.be.              594     IN      TXT     "test \""');
+
+        $this->assertSame('spatie.be', $record->host());
+        $this->assertSame(594, $record->ttl());
+        $this->assertSame('IN', $record->class());
+        $this->assertSame('TXT', $record->type());
+        $this->assertSame('test \\"', $record->txt());
+    }
 }


### PR DESCRIPTION
Good evening!

This PR aims to fix 2 bugs
- TXT record with double space. Ex: test 2  7
- TXT record with a double quote. Ex: test "

PR includes two new test case to cover those cases.