### PR TITLE
Label alias method, for uniform access to the records representative value

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ $records = $dns->getRecords('spatie.be')
 $hostNameOfFirstRecord = $records[0]->host();
 ```
 
+You can use `label()` to retrieve a representative label for a record .
+
+```php
+$records = $dns->getRecords('spatie.be')
+
+$hostNameOfFirstRecord = $records[0]->label(); 
+// if this is an A record it returns the ip if its a MX record the target
+```
+
 ## Support us
 
 [<img src="https://github-ads.s3.eu-central-1.amazonaws.com/dns.jpg?t=1" width="419px" />](https://spatie.be/github-ad-click/dns)

--- a/src/Records/A.php
+++ b/src/Records/A.php
@@ -9,6 +9,11 @@ class A extends Record
 {
     protected string $ip;
 
+    public function label(): string
+    {
+        return $this->ip;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
@@ -39,6 +44,7 @@ class A extends Record
             'class' => $this->class,
             'type' => $this->type,
             'ip' => $this->ip,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/AAAA.php
+++ b/src/Records/AAAA.php
@@ -9,6 +9,11 @@ class AAAA extends Record
 {
     protected string $ipv6;
 
+    public function label(): string
+    {
+        return $this->ipv6;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
@@ -39,6 +44,7 @@ class AAAA extends Record
             'class' => $this->class,
             'type' => $this->type,
             'ipv6' => $this->ipv6,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/CAA.php
+++ b/src/Records/CAA.php
@@ -13,6 +13,11 @@ class CAA extends Record
     protected string $tag;
     protected string $value;
 
+    public function label(): string
+    {
+        return $this->value;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 7);
@@ -57,6 +62,7 @@ class CAA extends Record
             'flags' => $this->flags,
             'tag' => $this->tag,
             'value' => $this->value,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/CNAME.php
+++ b/src/Records/CNAME.php
@@ -9,6 +9,11 @@ class CNAME extends Record
 {
     protected string $target;
 
+    public function label(): string
+    {
+        return $this->target;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
@@ -44,6 +49,7 @@ class CNAME extends Record
             'class' => $this->class,
             'type' => $this->type,
             'target' => $this->target,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/MX.php
+++ b/src/Records/MX.php
@@ -11,6 +11,11 @@ class MX extends Record
     protected int $pri;
     protected string $target;
 
+    public function label(): string
+    {
+        return $this->target;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 6);
@@ -53,6 +58,7 @@ class MX extends Record
             'type' => $this->type,
             'pri' => $this->pri,
             'target' => $this->target,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/NS.php
+++ b/src/Records/NS.php
@@ -9,6 +9,11 @@ class NS extends Record
 {
     protected string $target;
 
+    public function label(): string
+    {
+        return $this->target;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
@@ -44,6 +49,7 @@ class NS extends Record
             'class' => $this->class,
             'type' => $this->type,
             'target' => $this->target,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/PTR.php
+++ b/src/Records/PTR.php
@@ -9,6 +9,11 @@ class PTR extends Record
 {
     protected string $target;
 
+    public function label(): string
+    {
+        return $this->target;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
@@ -39,6 +44,7 @@ class PTR extends Record
             'class' => $this->class,
             'type' => $this->type,
             'target' => $this->target,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/Record.php
+++ b/src/Records/Record.php
@@ -44,6 +44,11 @@ abstract class Record implements Stringable
     }
 
     /**
+     * @return string representative string for this record
+     */
+    abstract public function label(): string;
+
+    /**
      * @param array $record
      *
      * @return static

--- a/src/Records/SOA.php
+++ b/src/Records/SOA.php
@@ -21,6 +21,11 @@ class SOA extends Record
     protected int $expire;
     protected int $minimum_ttl;
 
+    public function label(): string
+    {
+        return $this->mname;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 11);
@@ -98,6 +103,7 @@ class SOA extends Record
             'retry' => $this->retry,
             'expire' => $this->expire,
             'minimum_ttl' => $this->minimum_ttl,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/SRV.php
+++ b/src/Records/SRV.php
@@ -15,6 +15,11 @@ class SRV extends Record
     protected string $target;
     protected int $port;
 
+    public function label(): string
+    {
+        return $this->target;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 8);
@@ -71,6 +76,7 @@ class SRV extends Record
             'weight' => $this->weight,
             'port' => $this->port,
             'target' => $this->target,
+            'label' => $this->label(),
         ];
     }
 }

--- a/src/Records/TXT.php
+++ b/src/Records/TXT.php
@@ -9,6 +9,11 @@ class TXT extends Record
 {
     protected string $txt;
 
+    public function label(): string
+    {
+        return $this->txt;
+    }
+
     public static function parse(string $line): ?self
     {
         $attributes = static::lineToArray($line, 5);
@@ -44,6 +49,7 @@ class TXT extends Record
             'class' => $this->class,
             'type' => $this->type,
             'txt' => $this->txt,
+            'label' => $this->label(),
         ];
     }
 }

--- a/tests/Records/AAAATest.php
+++ b/tests/Records/AAAATest.php
@@ -37,6 +37,19 @@ class AAAATest extends TestCase
         $this->assertSame('2a00:1450:400e:800::200e', $record->ipv6());
     }
 
+    public function it_can_return_label()
+    {
+        $record = AAAA::make([
+            'host' => 'google.com',
+            'class' => 'IN',
+            'ttl' => 900,
+            'type' => 'AAAA',
+            'ipv6' => '2a00:1450:400e:800::200e',
+        ]);
+
+        $this->assertSame($record->ipv6(), $record->label());
+    }
+
     /** @test */
     public function it_can_transform_to_string()
     {
@@ -62,6 +75,7 @@ class AAAATest extends TestCase
         $this->assertSame('IN', $data['class']);
         $this->assertSame('AAAA', $data['type']);
         $this->assertSame('2a00:1450:400e:800::200e', $data['ipv6']);
+        $this->assertSame('2a00:1450:400e:800::200e', $data['label']);
     }
 
     /** @test */

--- a/tests/Records/ATest.php
+++ b/tests/Records/ATest.php
@@ -37,6 +37,19 @@ class ATest extends TestCase
         $this->assertSame('138.197.187.74', $record->ip());
     }
 
+    public function it_can_return_label()
+    {
+        $record = A::make([
+            'host' => 'spatie.be',
+            'class' => 'IN',
+            'ttl' => 900,
+            'type' => 'A',
+            'ip' => '138.197.187.74',
+        ]);
+
+        $this->assertSame($record->ip(), $record->label());
+    }
+
     /** @test */
     public function it_can_transform_to_string()
     {
@@ -62,6 +75,7 @@ class ATest extends TestCase
         $this->assertSame('IN', $data['class']);
         $this->assertSame('A', $data['type']);
         $this->assertSame('138.197.187.74', $data['ip']);
+        $this->assertSame('138.197.187.74', $data['label']);
     }
 
     /** @test */

--- a/tests/Records/CAATest.php
+++ b/tests/Records/CAATest.php
@@ -44,6 +44,22 @@ class CAATest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_label()
+    {
+        $record = CAA::make([
+            'host' => 'google.com',
+            'class' => 'IN',
+            'ttl' => 86400,
+            'type' => 'CAA',
+            'flags' => 0,
+            'tag' => 'issue',
+            'value' => 'pki.goog',
+        ]);
+
+        $this->assertSame($record->value(), $record->label());
+    }
+
+    /** @test */
     public function it_can_transform_to_string()
     {
         $record = CAA::parse('google.com.             86400   IN      CAA     0 issue "pki.goog"');
@@ -72,6 +88,7 @@ class CAATest extends TestCase
         $this->assertSame(0, $data['flags']);
         $this->assertSame('issue', $data['tag']);
         $this->assertSame('pki.goog', $data['value']);
+        $this->assertSame('pki.goog', $data['label']);
     }
 
     /** @test */

--- a/tests/Records/CNAMETest.php
+++ b/tests/Records/CNAMETest.php
@@ -37,6 +37,19 @@ class CNAMETest extends TestCase
         $this->assertSame('spatie.be', $record->target());
     }
 
+    public function it_can_return_label()
+    {
+        $record = CNAME::make([
+            'host' => 'www.spatie.be',
+            'class' => 'IN',
+            'ttl' => 300,
+            'type' => 'CNAME',
+            'target' => 'spatie.be',
+        ]);
+
+        $this->assertSame($record->target(), $record->label());
+    }
+
     /** @test */
     public function it_can_transform_to_string()
     {
@@ -62,6 +75,7 @@ class CNAMETest extends TestCase
         $this->assertSame('IN', $data['class']);
         $this->assertSame('CNAME', $data['type']);
         $this->assertSame('spatie.be', $data['target']);
+        $this->assertSame('spatie.be', $data['label']);
     }
 
     /** @test */

--- a/tests/Records/MXTest.php
+++ b/tests/Records/MXTest.php
@@ -40,6 +40,20 @@ class MXTest extends TestCase
         $this->assertSame('aspmx.l.google.com', $record->target());
     }
 
+    public function it_can_return_label()
+    {
+        $record = MX::make([
+            'host' => 'spatie.be',
+            'class' => 'IN',
+            'ttl' => 1665,
+            'type' => 'MX',
+            'pri' => 10,
+            'target' => 'ASPMX.L.GOOGLE.COM',
+        ]);
+
+        $this->assertSame($record->target(), $record->label());
+    }
+
     /** @test */
     public function it_can_transform_to_string()
     {
@@ -67,6 +81,7 @@ class MXTest extends TestCase
         $this->assertSame('MX', $data['type']);
         $this->assertSame(10, $data['pri']);
         $this->assertSame('aspmx.l.google.com', $data['target']);
+        $this->assertSame('aspmx.l.google.com', $data['label']);
     }
 
     /** @test */

--- a/tests/Records/NSTest.php
+++ b/tests/Records/NSTest.php
@@ -37,6 +37,19 @@ class NSTest extends TestCase
         $this->assertSame('ns1.openprovider.nl', $record->target());
     }
 
+    public function it_can_return_label()
+    {
+        $record = NS::make([
+            'host' => 'spatie.be',
+            'class' => 'IN',
+            'ttl' => 82516,
+            'type' => 'NS',
+            'target' => 'ns1.openprovider.nl',
+        ]);
+
+        $this->assertSame($record->target(), $record->label());
+    }
+
     /** @test */
     public function it_can_transform_to_string()
     {
@@ -62,6 +75,7 @@ class NSTest extends TestCase
         $this->assertSame('IN', $data['class']);
         $this->assertSame('NS', $data['type']);
         $this->assertSame('ns1.openprovider.nl', $data['target']);
+        $this->assertSame('ns1.openprovider.nl', $data['label']);
     }
 
     /** @test */

--- a/tests/Records/PTRTest.php
+++ b/tests/Records/PTRTest.php
@@ -45,6 +45,13 @@ class PTRTest extends TestCase
         $this->assertSame('ae0.452.fra.as205948.creoline.net.', $record->target());
     }
 
+    public function it_can_return_label($rDNS)
+    {
+        $record = PTR::parse($rDNS . '              3600     IN      PTR       ae0.452.fra.as205948.creoline.net.');
+
+        $this->assertSame($record->target(), $record->label());
+    }
+
     /** @test @dataProvider rDnsProvider */
     public function it_can_transform_to_string($rDNS)
     {
@@ -70,6 +77,7 @@ class PTRTest extends TestCase
         $this->assertSame('IN', $data['class']);
         $this->assertSame('PTR', $data['type']);
         $this->assertSame('ae0.452.fra.as205948.creoline.net.', $data['target']);
+        $this->assertSame('ae0.452.fra.as205948.creoline.net.', $data['label']);
     }
 
     /** @test @dataProvider rDnsProvider */

--- a/tests/Records/SOATest.php
+++ b/tests/Records/SOATest.php
@@ -56,6 +56,14 @@ class SOATest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_label()
+    {
+        $record = SOA::parse('spatie.be.              82393   IN      SOA     ns1.openprovider.nl. dns.openprovider.eu. 2020100801 10800 3600 604800 3600');
+
+        $this->assertSame($record->mname(), $record->label());
+    }
+
+    /** @test */
     public function it_can_transform_to_string()
     {
         $record = SOA::parse('spatie.be.              82393   IN      SOA     ns1.openprovider.nl. dns.openprovider.eu. 2020100801 10800 3600 604800 3600');
@@ -86,6 +94,7 @@ class SOATest extends TestCase
         $this->assertSame('IN', $data['class']);
         $this->assertSame('SOA', $data['type']);
         $this->assertSame('ns1.openprovider.nl', $data['mname']);
+        $this->assertSame('ns1.openprovider.nl', $data['label']);
         $this->assertSame('dns.openprovider.eu', $data['rname']);
         $this->assertSame(2020100801, $data['serial']);
         $this->assertSame(10800, $data['refresh']);

--- a/tests/Records/SRVTest.php
+++ b/tests/Records/SRVTest.php
@@ -47,6 +47,14 @@ class SRVTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_label()
+    {
+        $record = SRV::parse('_http._tcp.mxtoolbox.com. 3600  IN      SRV     10 100 80 mxtoolbox.com.');
+
+        $this->assertSame($record->target(), $record->label());
+    }
+
+    /** @test */
     public function it_can_transform_to_string()
     {
         $record = SRV::parse('_http._tcp.mxtoolbox.com. 3600  IN      SRV     10 100 80 mxtoolbox.com.');
@@ -77,6 +85,7 @@ class SRVTest extends TestCase
         $this->assertSame(100, $data['weight']);
         $this->assertSame(80, $data['port']);
         $this->assertSame('mxtoolbox.com', $data['target']);
+        $this->assertSame('mxtoolbox.com', $data['label']);
     }
 
     /** @test */

--- a/tests/Records/TXTTest.php
+++ b/tests/Records/TXTTest.php
@@ -46,6 +46,20 @@ class TXTTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_label()
+    {
+        $record = TXT::make([
+            'host' => 'spatie.be',
+            'class' => 'IN',
+            'ttl' => 594,
+            'type' => 'TXT',
+            'txt' => 'v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all',
+        ]);
+
+        $this->assertSame($record->txt(), $record->label());
+    }
+
+    /** @test */
     public function it_can_transform_to_string()
     {
         $record = TXT::parse('spatie.be.              594     IN      TXT     "v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all"');
@@ -70,6 +84,7 @@ class TXTTest extends TestCase
         $this->assertSame('IN', $data['class']);
         $this->assertSame('TXT', $data['type']);
         $this->assertSame('v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all', $data['txt']);
+        $this->assertSame('v=spf1 include:eu.mailgun.org include:spf.factuursturen.be include:sendgrid.net a mx ~all', $data['label']);
     }
 
     /** @test */


### PR DESCRIPTION
new: label method returns representative string for a record, like ip for an A record

I want to access a "representative" value for any given record without knowing what type of record it is.

I hope you see the use in this too. I'm happy to change the method name `label` to anything you deem more suitable.