### PR TITLE
Ability to fake responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ use Spatie\Dns\Dns;
 
 ## Faking DNS lookups (for testing)
 
-Similar to Laravel's `Http::fake()`, you can fake DNS lookups globally during a test.
+Using `Dns::fake()`, you can fake DNS lookups globally during a test.
 
 ```php
 use Spatie\Dns\Dns;

--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ use Spatie\Dns\Dns;
     ->getRecords('spatie.be');
 ```
 
+## Faking DNS lookups (for testing)
+
+Similar to Laravel's `Http::fake()`, you can fake DNS lookups globally during a test.
+
+```php
+use Spatie\Dns\Dns;
+
+Dns::fake([
+    'example.com' => [
+        'A' => [
+            'example.com.\t300\tIN\tA\t203.0.113.10',
+            ['host' => 'example.com.', 'ttl' => 300, 'class' => 'IN', 'type' => 'A', 'ip' => '203.0.113.11'],
+        ],
+    ],
+]);
+
+$records = (new Dns())->getRecords('example.com', 'A');
+
+Dns::fake(function (string $domain, array $types, $factory) {
+    return [
+        'A' => [
+            $factory->make('A', ['host' => $domain.'.', 'ttl' => 60, 'class' => 'IN', 'type' => 'A', 'ip' => '127.0.0.1']),
+        ],
+    ];
+});
+
+Dns::restore();
+```
+
 ## Specify retries and timeouts for Dig
 
 Dig can be configured to retry a DNS query after a certain timeout. Use `setRetries()` or `setTimeout()` to configure

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -7,11 +7,11 @@ use Spatie\Dns\Exceptions\InvalidArgument;
 use Spatie\Dns\Handlers\Dig;
 use Spatie\Dns\Handlers\DnsGetRecord;
 use Spatie\Dns\Handlers\Handler;
-use Spatie\Dns\Testing\DnsFake;
 use Spatie\Dns\Support\Collection;
 use Spatie\Dns\Support\Domain;
 use Spatie\Dns\Support\Factory;
 use Spatie\Dns\Support\Types;
+use Spatie\Dns\Testing\DnsFake;
 
 class Dns
 {

--- a/src/Testing/DnsFake.php
+++ b/src/Testing/DnsFake.php
@@ -35,16 +35,19 @@ class DnsFake extends Dns
             foreach ((array) $items as $item) {
                 if ($item instanceof Record) {
                     $records[] = $item;
+
                     continue;
                 }
 
                 if (is_string($item)) {
                     $records[] = $this->factory->parse($typeName, $item);
+
                     continue;
                 }
 
                 if (is_array($item)) {
                     $records[] = $this->factory->make($typeName, $item);
+
                     continue;
                 }
             }

--- a/src/Testing/DnsFake.php
+++ b/src/Testing/DnsFake.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Spatie\Dns\Testing;
+
+use Spatie\Dns\Dns;
+use Spatie\Dns\Records\Record;
+use Spatie\Dns\Support\Domain;
+use Spatie\Dns\Support\Factory;
+use Spatie\Dns\Support\Types;
+
+class DnsFake extends Dns
+{
+    /** @var array|callable|null */
+    protected $responder;
+
+    public function __construct(?Types $types = null, ?Factory $factory = null, array|callable|null $responder = null)
+    {
+        parent::__construct($types, $factory);
+
+        $this->responder = $responder ?? [];
+    }
+
+    public function getRecords(Domain|string $search, int|string|array $types = DNS_ALL): array
+    {
+        $domain = $this->sanitizeDomain(strval($search));
+        $typeNames = array_values($this->resolveTypes($types));
+
+        $response = $this->respond($domain, $typeNames);
+
+        $records = [];
+
+        foreach ($typeNames as $typeName) {
+            $items = $response[$typeName] ?? ($response['*'] ?? []);
+
+            foreach ((array) $items as $item) {
+                if ($item instanceof Record) {
+                    $records[] = $item;
+                    continue;
+                }
+
+                if (is_string($item)) {
+                    $records[] = $this->factory->parse($typeName, $item);
+                    continue;
+                }
+
+                if (is_array($item)) {
+                    $records[] = $this->factory->make($typeName, $item);
+                    continue;
+                }
+            }
+        }
+
+        return $records;
+    }
+
+    public function when(string $domain, array|callable $response): self
+    {
+        if (! is_array($this->responder)) {
+            $this->responder = [];
+        }
+
+        $this->responder[$domain] = $response;
+
+        return $this;
+    }
+
+    public function respondWith(callable $callback): self
+    {
+        $this->responder = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @param array<int,string> $typeNames
+     * @return array<string, array<int, Record|array|string>>
+     */
+    protected function respond(string $domain, array $typeNames): array
+    {
+        if (is_callable($this->responder)) {
+            $result = call_user_func($this->responder, $domain, $typeNames, $this->factory);
+
+            return is_array($result) ? $result : [];
+        }
+
+        $map = $this->responder ?? [];
+
+        $response = $map[$domain] ?? ($map['*'] ?? []);
+
+        if (is_callable($response)) {
+            $result = call_user_func($response, $domain, $typeNames, $this->factory);
+
+            return is_array($result) ? $result : [];
+        }
+
+        return is_array($response) ? $response : [];
+    }
+}

--- a/tests/DnsFakeTest.php
+++ b/tests/DnsFakeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Spatie\Dns\Dns;
+use Spatie\Dns\Records\A;
+use Spatie\Dns\Records\MX;
+use Spatie\Dns\Records\Record;
+
+afterEach(function () {
+    // Always restore the global fake between tests to avoid cross-test pollution
+    Dns::restore();
+});
+
+it('can fake dns lookups using a simple map', function () {
+    Dns::fake([
+        'example.com' => [
+            'A' => [
+                // String will be parsed via Factory
+                "example.com.\t300\tIN\tA\t203.0.113.10",
+                // Array will be passed to Factory::make
+                ['host' => 'example.com.', 'ttl' => 300, 'class' => 'IN', 'type' => 'A', 'ip' => '203.0.113.11'],
+            ],
+        ],
+    ]);
+
+    $records = (new Dns())->getRecords('example.com', 'A');
+
+    expect($records)->toHaveCount(2)
+        ->and($records[0])->toBeInstanceOf(Record::class)
+        ->and($records[0])->toBeInstanceOf(A::class)
+        ->and(in_array($records[0]->ip(), ['203.0.113.10', '203.0.113.11'], true))->toBeTrue();
+});
+
+it('can fake dns lookups using a callable', function () {
+    Dns::fake(function (string $domain, array $types, $factory) {
+        return [
+            'A' => [
+                $factory->make('A', [
+                    'host' => $domain . '.',
+                    'ttl' => 60,
+                    'class' => 'IN',
+                    'type' => 'A',
+                    'ip' => '127.0.0.1',
+                ]),
+            ],
+        ];
+    });
+
+    $records = (new Dns())->getRecords('my.test', 'A');
+
+    expect($records)->toHaveCount(1)
+        ->and($records[0])->toBeInstanceOf(A::class)
+        ->and($records[0]->ip())->toBe('127.0.0.1');
+});
+
+it('supports wildcard type responses in map mode', function () {
+    Dns::fake([
+        'example.org' => [
+            '*' => [
+                // Will be returned for any type when a specific type key is not defined
+                ['host' => 'example.org.', 'ttl' => 120, 'class' => 'IN', 'type' => 'MX', 'pri' => 10, 'target' => 'mail.example.org.'],
+            ],
+        ],
+    ]);
+
+    $mx = (new Dns())->getRecords('example.org', 'MX');
+
+    expect($mx)->toHaveCount(1)
+        ->and($mx[0])->toBeInstanceOf(MX::class)
+        ->and($mx[0]->target())->toBe('mail.example.org');
+});
+
+it('supports wildcard domain responses in map mode', function () {
+    Dns::fake([
+        '*' => [
+            'A' => [
+                ['host' => 'any.tld.', 'ttl' => 60, 'class' => 'IN', 'type' => 'A', 'ip' => '198.51.100.5'],
+            ],
+        ],
+    ]);
+
+    $records = (new Dns())->getRecords('another.test', 'A');
+
+    expect($records)->toHaveCount(1)
+        ->and($records[0])->toBeInstanceOf(A::class)
+        ->and($records[0]->ip())->toBe('198.51.100.5');
+});
+
+it('toggles isFaked and can be restored', function () {
+    expect(Dns::isFaked())->toBeFalse();
+
+    Dns::fake([
+        'x.test' => [ 'A' => [] ],
+    ]);
+
+    expect(Dns::isFaked())->toBeTrue();
+
+    Dns::restore();
+
+    expect(Dns::isFaked())->toBeFalse();
+});


### PR DESCRIPTION
While working on a TDD project, I noticed there's no way to fake responses using this package.
This PR is not perfect as it only covers the `getRecords` method, but it's better than nothing.