### PR TITLE
Support null MX and SRV records that use the root label

### DIFF
--- a/src/Records/Record.php
+++ b/src/Records/Record.php
@@ -104,6 +104,13 @@ abstract class Record implements Stringable
 
     protected function prepareDomain(string $value): string
     {
+        // The root label "." is a valid target for a null MX (RFC 7505) and for an
+        // SRV record that declines a service (RFC 2782). Stored dot-stripped like every
+        // other domain, the root becomes an empty string and __toString re-appends the dot.
+        if (trim($value, '.') === '') {
+            return '';
+        }
+
         return strval(new Domain(trim($value, '.')));
     }
 

--- a/src/Records/Record.php
+++ b/src/Records/Record.php
@@ -107,7 +107,7 @@ abstract class Record implements Stringable
         // The root label "." is a valid target for a null MX (RFC 7505) and for an
         // SRV record that declines a service (RFC 2782). Stored dot-stripped like every
         // other domain, the root becomes an empty string and __toString re-appends the dot.
-        if (trim($value, '.') === '') {
+        if ($value === '.') {
             return '';
         }
 

--- a/tests/Records/MXTest.php
+++ b/tests/Records/MXTest.php
@@ -61,3 +61,16 @@ it('returns null for too few attributes', function () {
 
     expect($record)->toBeNull();
 });
+
+it('can parse a null MX record', function () {
+    $record = MX::parse('spatie.be.              1665    IN      MX      0 .');
+
+    expect($record->pri())->toBe(0);
+    expect($record->target())->toBe('');
+});
+
+it('can transform a null MX record to string', function () {
+    $record = MX::parse('spatie.be.              1665    IN      MX      0 .');
+
+    expect(strval($record))->toBe("spatie.be.\t\t1665\tIN\tMX\t0\t.");
+});

--- a/tests/Records/SRVTest.php
+++ b/tests/Records/SRVTest.php
@@ -71,3 +71,18 @@ it('returns null for too few attributes', function () {
 
     expect($record)->toBeNull();
 });
+
+it('can parse an SRV record that declines a service', function () {
+    $record = SRV::parse('_sip._tcp.spatie.be.      3600  IN      SRV     0 0 0 .');
+
+    expect($record->pri())->toBe(0);
+    expect($record->weight())->toBe(0);
+    expect($record->port())->toBe(0);
+    expect($record->target())->toBe('');
+});
+
+it('can transform a declined SRV record to string', function () {
+    $record = SRV::parse('_sip._tcp.spatie.be.      3600  IN      SRV     0 0 0 .');
+
+    expect(strval($record))->toBe("_sip._tcp.spatie.be.\t\t3600\tIN\tSRV\t0\t0\t0\t.");
+});


### PR DESCRIPTION
Parsing a null MX (RFC 7505) or a service-declining SRV (RFC 2782) threw `InvalidArgument::domainIsMissing`, because the root label `.` was fed to `Domain` as an empty host. Both are valid records that appear in the wild:

```
example.com.            3600    IN      MX      0 .
_sip._tcp.example.com.  3600    IN      SRV     0 0 0 .
```

This PR allows the package to parse and round-trip them instead of rejecting them.
